### PR TITLE
feat: lower PHP requirement to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "type": "library",
     "homepage": "https://github.com/grazulex/laravel-multipersona",
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "illuminate/support": "^11.0|^12.0",
         "nesbot/carbon": "^3.10"
     },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -645,7 +645,7 @@ php artisan multipersona:cleanup-expired
 ## Package Information
 
 - **Version**: 1.0.0
-- **PHP Requirements**: >= 8.3
+- **PHP Requirements**: >= 8.2
 - **Laravel Requirements**: >= 10.0
 - **License**: MIT
 - **Repository**: https://github.com/Grazulex/laravel-multipersona

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- PHP 8.3+
+ - PHP 8.2+
 - Laravel 10.x or 11.x
 - Laravel-supported database (MySQL, PostgreSQL, SQLite, etc.)
 


### PR DESCRIPTION
## Summary
- allow installation with PHP 8.2 or newer
- document the PHP 8.2 minimum requirement

## Testing
- `composer validate`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896ca6b1bbc8330aff270d6104b4620